### PR TITLE
Replace implicit wallet saving with explicit sync_and_save wrapper

### DIFF
--- a/src/taker/routines.rs
+++ b/src/taker/routines.rs
@@ -2,12 +2,11 @@
 //!
 //! It includes functions for handshaking, requesting contract signatures, sending proofs of funding, and downloading maker offers.
 //! It also defines structs for contract transactions and contract information.
-//! Notable types include [ContractTransaction], [ContractsInfo], [ThisMakerInfo], and [NextMakerInfo].
+//! Notable types include [ThisMakerInfo], and [NextMakerInfo].
 //! It also handles downloading maker offers with retry mechanisms and implements the necessary message structures
 //! for communication between taker and maker.
 
 use chrono::Utc;
-use serde::{Deserialize, Serialize};
 use socks::Socks5Stream;
 use std::{net::TcpStream, thread::sleep, time::Duration};
 
@@ -44,21 +43,6 @@ use crate::taker::api::{
 };
 
 use crate::wallet::SwapCoin;
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub(crate) struct ContractTransaction {
-    pub(crate) tx: Transaction,
-    pub(crate) redeemscript: ScriptBuf,
-    pub(crate) hashlock_spend_without_preimage: Option<Transaction>,
-    pub(crate) timelock_spend: Option<Transaction>,
-    pub(crate) timelock_spend_broadcasted: bool,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub(crate) struct ContractsInfo {
-    pub(crate) contract_txes: Vec<ContractTransaction>,
-    pub(crate) wallet_label: String,
-}
 
 /// Make a handshake with a maker.
 /// Ensures that the Maker is alive and responding.

--- a/src/wallet/split_utxos.rs
+++ b/src/wallet/split_utxos.rs
@@ -65,7 +65,7 @@ impl Wallet {
                 let sum: f64 = randomized.iter().sum();
                 let normalized: Vec<u64> = randomized
                     .iter()
-                    .map(|&r| ((total as f64 * r / sum).round() as u64))
+                    .map(|&r| (total as f64 * r / sum).round() as u64)
                     .collect();
 
                 // Fix rounding errors


### PR DESCRIPTION
The `wallet.sync()` function used to indirectly write to disk by calling `update_external_index()`, which performed a `wallet.save_to_disk()`. This behavior was implicit and done before sync end, `refresh_offer_maxsize_cache()` was called before and therefore not persisted, leading to inconsistencies.

# Solution

This PR removes the implicit saving behavior from `update_external_index()` and introduces an explicit `sync_and_save()` wrapper function that:
1. Calls `sync()`
2. Then performs a `save_to_disk()`

All previous usages of `wallet.sync()` where saving was intended have been replaced with `wallet.sync_and_save()` to make saving behavior explicit and consistent.

# Additional Changes

- Removed the `save_to_disk()` call from `update_external_index()`
- Added a warning comment to `get_next_external_address()`, which remains the only function with indirect save behavior
- Applied `cargo fmt` to ensure consistent formatting

# Why it matters

This change improves code clarity, avoids unintentional wallet persistence, and ensures that wallet modifications are only saved when explicitly intended.